### PR TITLE
Extra options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ With a `ApiCall` builder (the object returned by `apiCall`), we can chain many o
 - `withJsonBody(object, options?: SerializationOptions)`: adds JSON request body
 - `withFormDataBody(FormData, options?: SerializationOptions)`: adds form-data request body
 - `withURLEncodedBody(object, options?: SerializationOptions)`: adds 'application/x-www-form-urlencoded' request body
+- `withExtraOptions(options: ExtraOptions)`: escape hatch to add extra options to `fetch` while still using the builder pattern
 - `expectStatus(number)`: throw an error if the response status isn't the expected one
 - `expectSuccessStatus()`: throw an error if the response status isn't in 200 range
 - `onResponse(callback)`: calls your function whenever responses are received
@@ -111,4 +112,24 @@ import fetch from 'cross-fetch';
 import { setGlobalFetch } from '@lcdev/fetch';
 
 setGlobalFetch(fetch);
+```
+
+## Client Certificates
+
+Some API servers require a client TLS certificate to authenticate against their API.
+In NodeJS, you can do this using a custom HTTPS agent that is aware of the client certificate.
+Then you can use `.withExtraOptions()` to pass the custom `agent` to the `fetch` options
+
+_Note: `agent` is a non-standard option for `node-fetch`._
+
+```typescript
+import * as https from 'https';
+
+const myApi = api('https://base-url.com')
+  .withBearerToken({ token: '...' })
+  .withExtraOptions({
+    agent: new https.Agent({
+      pfx: myPfxClientCertificate,
+    }),
+  });
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lcdev/fetch",
   "description": "Wrapper for DOM fetch",
-  "version": "0.1.10",
+  "version": "0.1.11-alpha.1",
   "license": "MPL-2.0",
   "sideEffects": false,
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lcdev/fetch",
   "description": "Wrapper for DOM fetch",
-  "version": "0.1.11-alpha.1",
+  "version": "0.1.10",
   "license": "MPL-2.0",
   "sideEffects": false,
   "author": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,5 @@
 import * as http from 'http';
+import * as https from 'https';
 import { HttpMethod, buildPath, api, apiCall } from './index';
 
 import 'cross-fetch/polyfill';
@@ -133,7 +134,7 @@ describe('api transforms', () => {
     });
   });
 
-  test('with base url and transfomr', () => {
+  test('with base url and transform', () => {
     const test = api('//foo').withBearerToken({ token: 'token' });
     const test1 = test.withBaseURL('/api/v1');
 
@@ -167,6 +168,40 @@ describe('api transforms', () => {
     expect(myApi.get('/api').build()).toMatchObject({
       method: 'GET',
       path: 'https://my-other-api/api',
+    });
+  });
+});
+
+describe('extra options', () => {
+  test('agent option', async () => {
+    const customAgent = new https.Agent();
+    expect(
+      apiCall('/', HttpMethod.GET).withExtraOptions({ agent: customAgent }).build(),
+    ).toMatchObject({
+      path: '/',
+      agent: customAgent,
+    });
+  });
+
+  test('multiple extra options call', async () => {
+    expect(
+      apiCall('/', HttpMethod.GET)
+        .withExtraOptions({ first: 'abc' })
+        .withExtraOptions({ second: 'def' })
+        .build(),
+    ).toMatchObject({
+      path: '/',
+      first: 'abc',
+      second: 'def',
+    });
+  });
+
+  test('extra options overwrite other builders', async () => {
+    expect(
+      apiCall('/', HttpMethod.GET).withExtraOptions({ path: '/other', method: 'POST' }).build(),
+    ).toMatchObject({
+      path: '/other',
+      method: 'POST',
     });
   });
 });


### PR DESCRIPTION
Escape hatch to add extra options to `fetch` while still using the builder pattern. Useful for non-standard options like `agent` in `node-fetch` so that you can pass client TLS certificates.

```typescript
import * as https from 'https';

const myApi = api('https://base-url.com')
  .withBearerToken({ token: '...' })
  .withExtraOptions({
    agent: new https.Agent({
      pfx: myPfxClientCertificate,
    }),
  });
```