### PR TITLE
On pre-build hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ With a `ApiCall` builder (the object returned by `apiCall`), we can chain many o
 - `withExtraOptions(options: ExtraOptions)`: escape hatch to add extra options to `fetch` while still using the builder pattern
 - `expectStatus(number)`: throw an error if the response status isn't the expected one
 - `expectSuccessStatus()`: throw an error if the response status isn't in 200 range
+- `onPreBuild(callback)`: calls your function before options are built for every `fetch`
 - `onResponse(callback)`: calls your function whenever responses are received
 - `onJsonResponse(callback)`: calls your function whenever JSON responses are received
 - `build()`: constructs options that can be passed into `fetch` directly

--- a/src/index.ts
+++ b/src/index.ts
@@ -399,7 +399,7 @@ class ApiCallImpl<Method extends HttpMethod> implements ApiCall<Method> {
     this.consumed = true;
 
     return this.onPreBuildCbs
-      .reduce((acc, cb) => acc.then(() => cb()), Promise.resolve())
+      .reduce((acc, callback) => acc.then(callback), Promise.resolve())
       .then(() => {
         const { path, ...options } = this.build();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export interface BearerToken {
   token?: string;
 }
 
+export type OnPreBuild = () => void | Promise<void>;
 export type OnResponse = (r: Response) => void | Promise<void>;
 export type OnJsonResponse = (data: Json, r: Response) => void | Promise<void>;
 
@@ -69,6 +70,7 @@ export interface ApiCall<Method extends HttpMethod> extends Promise<Response> {
   expectStatus(code: number): ApiCall<Method>;
   expectSuccessStatus(): ApiCall<Method>;
 
+  onPreBuild(cb: OnPreBuild): ApiCall<Method>;
   onResponse(cb: OnResponse): ApiCall<Method>;
   onJsonResponse(cb: OnJsonResponse): ApiCall<Method>;
 
@@ -100,6 +102,7 @@ export interface Api {
   withBaseURL(path: string): Api;
   withExtraOptions(options: ExtraOptions): Api;
 
+  onPreBuild(cb: OnPreBuild): Api;
   onResponse(cb: OnResponse): Api;
   onJsonResponse(cb: OnJsonResponse): Api;
 
@@ -141,6 +144,10 @@ export const api = (baseURL: string, transforms: ApiCallTransform<any>[] = []): 
     return withTransform((c) => c.withExtraOptions(options));
   };
 
+  const onPreBuild = (cb: OnPreBuild) => {
+    return withTransform((c) => c.onPreBuild(cb));
+  };
+
   const onResponse = (cb: OnResponse) => {
     return withTransform((c) => c.onResponse(cb));
   };
@@ -155,6 +162,7 @@ export const api = (baseURL: string, transforms: ApiCallTransform<any>[] = []): 
     withBearerToken,
     withBaseURL,
     withExtraOptions,
+    onPreBuild,
     onResponse,
     onJsonResponse,
     get: (path) => call<HttpMethod.GET>(path, HttpMethod.GET),
@@ -210,6 +218,7 @@ class ApiCallImpl<Method extends HttpMethod> implements ApiCall<Method> {
   private consumed = false;
   private queryOptions?: SerializationOptions;
   private bodyOptions?: SerializationOptions;
+  private onPreBuildCbs: OnPreBuild[] = [];
   private onResponseCbs: OnResponse[] = [];
   private onJsonResponseCbs: OnJsonResponse[] = [];
 
@@ -327,6 +336,11 @@ class ApiCallImpl<Method extends HttpMethod> implements ApiCall<Method> {
     });
   }
 
+  onPreBuild(cb: OnPreBuild) {
+    this.onPreBuildCbs.push(cb);
+    return this;
+  }
+
   onResponse(cb: OnResponse) {
     this.onResponseCbs.push(cb);
     return this;
@@ -384,16 +398,20 @@ class ApiCallImpl<Method extends HttpMethod> implements ApiCall<Method> {
 
     this.consumed = true;
 
-    const { path, ...options } = this.build();
+    return this.onPreBuildCbs
+      .reduce((acc, cb) => acc.then(() => cb()), Promise.resolve())
+      .then(() => {
+        const { path, ...options } = this.build();
 
-    const localFetch = globalFetch ?? fetch;
+        const localFetch = globalFetch ?? fetch;
 
-    return localFetch(path, options).then((response) => {
-      return this.onResponseCbs
-        .reduce((acc, cb) => acc.then(() => cb(response)), Promise.resolve())
-        .then(() => response)
-        .then(onfulfilled, onrejected);
-    });
+        return localFetch(path, options).then((response) => {
+          return this.onResponseCbs
+            .reduce((acc, cb) => acc.then(() => cb(response)), Promise.resolve())
+            .then(() => response)
+            .then(onfulfilled, onrejected);
+        });
+      });
   };
 
   catch: Promise<Response>['catch'] = async (onrejected) => {


### PR DESCRIPTION
Hook that is called before options are built for every `fetch`. Useful when used server side to ensure auth tokens are always valid (ie. if auth token expired, refresh it before making the next request). This makes DX ergonomics really nice - you never have to worry about tokens, it just automatically refreshes for you, or reuses token if still valid.

```typescript
const someApi = api(base)
  .withBearerToken(auth)
  .onPreBuild(async () => {
    await auth.keepAlive();
  });
```